### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -373,7 +373,7 @@ Resources:
           # V56536055 - 10/08/2018 - better logging capabilities
           LOG_LEVEL: 'INFO' #change to WARN, ERROR or DEBUG as needed
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 600
       Role: !GetAtt LambdaESCognitoRole.Arn
       Code:


### PR DESCRIPTION
CloudFormation templates in amazon-comprehend-doc-search have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.